### PR TITLE
Charsets and collation as envvars

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -4,6 +4,12 @@ parameters:
     # environment variables are not available yet.
     # You should not need to change this value.
     env(DATABASE_URL): ''
+    env(CHARSET): 'utf8'
+    env(COLLATE): 'utf8_general_ci'
+    charset: '%env(CHARSET)%'
+    collate: '%env(COLLATE)%'
+    env(MYSQL_ATTR_INIT_COMMAND): "SET NAMES '%charset%' COLLATE '%collate%'"
+
 
 doctrine:
     dbal:
@@ -13,7 +19,13 @@ doctrine:
                 url: '%env(resolve:SOURCE_DATABASE_URL)%'
                 options:
                     !php/const PDO::MYSQL_ATTR_USE_BUFFERED_QUERY: 0
+                    charset: '%env(resolve:CHARSET)%'
+                    collate: '%env(resolve:COLLATE)%'
+                    !php/const PDO::MYSQL_ATTR_INIT_COMMAND: '%env(resolve:MYSQL_ATTR_INIT_COMMAND)%'
             target:
                 options:
                     !php/const PDO::MYSQL_ATTR_LOCAL_INFILE: 1
+                    charset: '%env(resolve:CHARSET)%'
+                    collate: '%env(resolve:COLLATE)%'
+                    !php/const PDO::MYSQL_ATTR_INIT_COMMAND: '%env(resolve:MYSQL_ATTR_INIT_COMMAND)%'
                 url: '%env(resolve:TARGET_DATABASE_URL)%'

--- a/docker-compose.test-mysql.yml
+++ b/docker-compose.test-mysql.yml
@@ -16,5 +16,7 @@ services:
     image: mysql:5.7
   app:
     environment:
+      CHARSET: utf8
+      COLLATE: utf8_general_ci
       SOURCE_DATABASE_URL: mysql://user:pass@mysql_test_source:3306/source
       TARGET_DATABASE_URL: mysql://user:pass@mysql_test_target:3306/target

--- a/src/Fogger/Schema/SchemaManipulator.php
+++ b/src/Fogger/Schema/SchemaManipulator.php
@@ -9,10 +9,13 @@ class SchemaManipulator
 {
     private $sourceSchema;
 
+    private $sourceConnection;
+
     private $targetSchema;
 
     public function __construct(Connection $source, Connection $target)
     {
+        $this->sourceConnection = $source;
         $this->sourceSchema = $source->getSchemaManager();
         $this->targetSchema = $target->getSchemaManager();
     }
@@ -33,6 +36,12 @@ class SchemaManipulator
             }
             foreach ($table->getIndexes() as $index) {
                 $table->dropIndex($index->getName());
+            }
+            if (!$table->hasOption('collate')) {
+                $table->addOption(
+                    'collate',
+                    $this->sourceConnection->getParams()['driverOptions']['collate']
+                );
             }
             $this->targetSchema->createTable($table);
         }


### PR DESCRIPTION
Allow the setting of charset and collation as envvars and create tables with the collation used by the source driver, rather than an arbitrary default.