### PR TITLE
[MB-1761] Update autoincrements

### DIFF
--- a/src/Command/FinishCommand.php
+++ b/src/Command/FinishCommand.php
@@ -92,6 +92,8 @@ class FinishCommand extends Command
             $this->schemaManipulator->recreateIndexes();
             $output->writeln(' - recreating foreign keys...');
             $this->schemaManipulator->recreateForeignKeys();
+            $output->writeln(' - updating auto_increments...');
+            $this->schemaManipulator->updateAutoIncrements();
         } catch (\Exception $exception) {
             $this->outputMessage(sprintf("There has been an error:\n\n%s", $exception->getMessage()), $io);
 

--- a/src/Fogger/Schema/SchemaManipulator.php
+++ b/src/Fogger/Schema/SchemaManipulator.php
@@ -106,16 +106,16 @@ class SchemaManipulator
         foreach ($sourceTables as $table) {
             foreach ($table->getColumns() as $column) {
                 if ($column->getAutoincrement()) {
-                    $max = $this->sourceConnection->fetchColumn(
-                        "SELECT MAX(" .$column->getName().") FROM ".$table->getName()
-                    );
+                    $auto_inc = $this->sourceConnection->fetchAssoc(
+                        "SHOW TABLE STATUS WHERE Name LIKE '".$table->getName()."'"
+                    )['Auto_increment'];
                     echo(sprintf(
                         "  - %s auto_increment to %s\n",
                         $table->getName(),
-                        $max + 1
+                        $auto_inc
                     ));
                     $this->targetConnection->query(
-                        "ALTER TABLE ".$table->getName()." AUTO_INCREMENT = ".($max+1)
+                        "ALTER TABLE ".$table->getName()." AUTO_INCREMENT = ". $auto_inc
                     );
                     break;
                 }


### PR DESCRIPTION
Read source table AUTO_INCREMENTS at end and apply to target, this will prevent anything introduced during the data copy from being erroneously included in data added on the target.